### PR TITLE
Drop support for BME280 in favor of stability

### DIFF
--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/boschIotHub.cpp
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/boschIotHub.cpp
@@ -79,7 +79,7 @@ void BoschIotHub::connectDevice(const char* deviceId, const char* authId, const 
     mqttClient.loop();
 }
 
-void BoschIotHub::publish(String payload) {
+bool BoschIotHub::publish(String payload) {
   Printer::printlnMsg("Bosch IoT Hub", payload);
   /* Publish all available data to the MQTT broker */
   const char* topic = "telemetry";
@@ -95,5 +95,8 @@ void BoschIotHub::publish(String payload) {
   if (!publishResult) {
     Printer::printMsg("Bosch IoT Hub", "Publish failed");
     Serial.println(publishResult);
+    return false;
   }
+
+  return true;
 }

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/boschIotHub.h
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/boschIotHub.h
@@ -49,7 +49,7 @@ class BoschIotHub {
     bool connect();
     bool deviceIsConnected();
     void connectDevice(const char* deviceId, const char* authId, const char* devicePassword);
-    void publish(String payload);
+    bool publish(String payload);
 };
 
 #endif

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus-mqtt.ino
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus-mqtt.ino
@@ -71,11 +71,14 @@ void loop() {
     memset(&bno055Values, 0, sizeof(bno055Values));
     octopus.readBme680(bme680Values);
     octopus.readBno055(bno055Values);
-    octopus.readBme280(bme680Values);
     float vcc = octopus.getVcc();
 
     printSensorData(vcc, bme680Values, bno055Values);
-    publishSensorData(vcc, bme680Values, bno055Values);
+    if(publishSensorData(vcc, bme680Values, bno055Values))
+      octopus.showColor(1, 0, 0x80, 0, 0); // green
+    else
+      octopus.showColor(1, 0x80, 0, 0, 0); // red
+
     Serial.println();
   }
   delay(LOOP_DELAY);

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.cpp
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.cpp
@@ -38,7 +38,6 @@ void Octopus::begin() {
   delay(1000); // give sensors some time to start up
   this->initBme680();
   this->initBno055();
-  this->initBme280();
   delay(500);
   
   this->showColor(0, 0, 0x80, 0, 0); // green
@@ -128,7 +127,7 @@ bool Octopus::readBme680(Bme680Values &values) {
     return false;
 
 
-  if (!this->bme680.performReading()) { 
+  if (!this->bme680.performReading()) {
     Serial.println("Sensor reading failure");
     return false;
   } else {
@@ -139,19 +138,6 @@ bool Octopus::readBme680(Bme680Values &values) {
     values.altitude = bme680.readAltitude(SEALEVELPRESSURE_HPA);
     return true;
   }
-}
-
-bool Octopus::readBme280(Bme680Values &values) {
-  if(!bme280Ready)
-    return false;
-
-  this->bme280.begin(0x77);
-  values.temperature = this->bme280.readTemperature();
-  values.pressure = this->bme280.readPressure();
-  values.humidity = this->bme280.readHumidity();
-  values.gas_resistance = 0;
-  values.altitude = this->bme280.readAltitude(SEALEVELPRESSURE_HPA);
-  return true;
 }
 
 void Octopus::initBme680() {
@@ -178,17 +164,6 @@ void Octopus::initBno055() {
     Serial.println("OK");
   } else {
     bno055Ready = false;
-    Serial.println("Not found");
-  }
-}
-
-void Octopus::initBme280() {
-  Printer::printMsg("Octopus", "Initializing BME280: ");
-  if (this->bme280.begin()) {
-    bme280Ready = true;
-    Serial.println("OK");
-  } else {
-    bme280Ready = false;
     Serial.println("Not found");
   }
 }

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.h
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.h
@@ -29,7 +29,6 @@
 #include <Adafruit_Sensor.h>  // Make sure you have the Adafruit Sensor library installed
 #include <Adafruit_BME680.h>  // Make sure you have the Adafruit BME680 library installed
 #include <Adafruit_BNO055.h>  // Make sure you have the Adafruit BNO055 library installed
-#include <Adafruit_BME280.h>  // Make sure you have the Adafruit BME280 library installed
 #include <utility/imumaths.h>
 #include <Adafruit_NeoPixel.h> // Make sure you have the Adafruit NeoPixel library installed
 
@@ -72,20 +71,17 @@ struct Bme680Values {
 
 class Octopus {
  
-  Adafruit_BME680 bme680; // I2C
+  Adafruit_BME680 bme680 = Adafruit_BME680(); // I2C
   Adafruit_BNO055 bno055 = Adafruit_BNO055(55);
-  Adafruit_BME280 bme280; // I2C
   Adafruit_NeoPixel strip = Adafruit_NeoPixel(2, PIN_NEOPIXEL, NEO_GRBW + NEO_KHZ800);
   
   void initLights();
   void initBme680();
   void initBno055();
-  void initBme280();
   void setupNTP();
 
   bool bme680Ready;
   bool bno055Ready;
-  bool bme280Ready;
   
   public:
     void begin();
@@ -94,7 +90,6 @@ class Octopus {
     float getVcc ();
     bool readBno055(Bno055Values &values);
     bool readBme680(Bme680Values &values);
-    bool readBme280(Bme680Values &values);
 };
 
 #endif

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/sensorPublish.ino
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/sensorPublish.ino
@@ -85,10 +85,10 @@ String sensor3dValueString(const String& featureName, float xValue, float yValue
   return output;
 }
 
-void publishSensorData(float power, const Bme680Values& bme680Values, const Bno055Values& bno055Values) {
+bool publishSensorData(float power, const Bme680Values& bme680Values, const Bno055Values& bno055Values) {
 
   updateMinMax(power, bme680Values, bno055Values);
-  hub.publish(publishSensorDataString(power, bme680Values, bno055Values));
+  return hub.publish(publishSensorDataString(power, bme680Values, bno055Values));
 }
 
 void updateMinMax(float power, const Bme680Values& bme680Values, const Bno055Values& bno055Values) {


### PR DESCRIPTION
During extensive testing we noticed that with the current firmware we
cannot read the I2C sensors after some minutes. Potentially the bus locks
up and you can only resolve this by powering off the board for some minutes.
A simple reset does NOT do the job.

I am afraid that there is a clash between the two BME drivers.

To overcome this, this PR removes support for BME280. With my test board I
could get the sensor data for days without a lock up.