### PR TITLE
Enable either BME280 or BME680 by compiler flag

### DIFF
--- a/octopus-hub-things-example/README.md
+++ b/octopus-hub-things-example/README.md
@@ -48,8 +48,8 @@ There you can write the code that should be executed on your board and upload it
 2. Configure [ESP8266 board support](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266/using-arduino-ide#install-the-esp8266-board-package)
 3. Install the following libraries (Sketch > Include Library > Manage Libraries)
     * [Adafruit Unified Sensor library](https://github.com/adafruit/Adafruit_Sensor)
-    * [Adafruit BME680 library](https://github.com/adafruit/Adafruit_BME680)
-    * [Adafruit BME280 library](https://github.com/adafruit/Adafruit_BME280)
+    * [Adafruit BME680 library](https://github.com/adafruit/Adafruit_BME680) (If your board has a BME680 instead of BME280)
+    * [Adafruit BME280 library](https://github.com/adafruit/Adafruit_BME280) (If your board has a BME280 instead of BME680)
     * [Adafruit BNO055 library](https://github.com/adafruit/Adafruit_BNO055)
     * [Adafruit NeoPixel library](https://github.com/adafruit/Adafruit_NeoPixel)
     * [PubSubClient library](https://github.com/knolleary/pubsubclient)
@@ -211,6 +211,8 @@ Just create this file from the following template and replace XXX placeholders w
 // Do not change this
 #define MQTT_BROKER "mqtt.bosch-iot-hub.com"
 #define MQTT_PORT 8883
+
+//#define BME280 // uncomment this line if your board has a BME280 instead of BME680
 
 extern const unsigned char mqtt_server_ca[];
 extern const unsigned int mqtt_server_ca_len;

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus-mqtt.ino
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus-mqtt.ino
@@ -69,9 +69,12 @@ void loop() {
     static Bno055Values bno055Values;
     memset(&bme680Values, 0, sizeof(bme680Values));
     memset(&bno055Values, 0, sizeof(bno055Values));
-    octopus.readBme680(bme680Values);
     octopus.readBno055(bno055Values);
+    #ifdef BME280
     octopus.readBme280(bme680Values);
+    #else
+    octopus.readBme680(bme680Values);
+    #endif
     float vcc = octopus.getVcc();
 
     printSensorData(vcc, bme680Values, bno055Values);

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.cpp
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.cpp
@@ -36,9 +36,12 @@ void Octopus::begin() {
   this->initLights();
   
   delay(1000); // give sensors some time to start up
-  this->initBme680();
-  this->initBno055();
+  #ifdef BME280
   this->initBme280();
+  #else
+  this->initBme680();
+  #endif
+  this->initBno055();
   delay(500);
   
   this->showColor(0, 0, 0x80, 0, 0); // green
@@ -123,6 +126,33 @@ bool Octopus::readBno055(Bno055Values &values) {
   return true;
 }
 
+#if BME280
+void Octopus::initBme280() {
+  Printer::printMsg("Octopus", "Initializing BME280: ");
+  if (this->bme280.begin()) {
+    bme280Ready = true;
+    Serial.println("OK");
+  } else {
+    bme280Ready = false;
+    Serial.println("Not found");
+  }
+}
+
+bool Octopus::readBme280(Bme680Values &values) {
+  if(!bme280Ready)
+    return false;
+
+  this->bme280.begin(0x77);
+  values.temperature = this->bme280.readTemperature();
+  values.pressure = this->bme280.readPressure();
+  values.humidity = this->bme280.readHumidity();
+  values.gas_resistance = 0;
+  values.altitude = this->bme280.readAltitude(SEALEVELPRESSURE_HPA);
+  return true;
+}
+
+#else
+
 bool Octopus::readBme680(Bme680Values &values) {
   if(!bme680Ready)
     return false;
@@ -141,19 +171,6 @@ bool Octopus::readBme680(Bme680Values &values) {
   }
 }
 
-bool Octopus::readBme280(Bme680Values &values) {
-  if(!bme280Ready)
-    return false;
-
-  this->bme280.begin(0x77);
-  values.temperature = this->bme280.readTemperature();
-  values.pressure = this->bme280.readPressure();
-  values.humidity = this->bme280.readHumidity();
-  values.gas_resistance = 0;
-  values.altitude = this->bme280.readAltitude(SEALEVELPRESSURE_HPA);
-  return true;
-}
-
 void Octopus::initBme680() {
   Printer::printMsg("Octopus", "Initializing BME680: ");
   if (this->bme680.begin(0x76)) {
@@ -170,6 +187,8 @@ void Octopus::initBme680() {
   }
 }
 
+#endif
+
 void Octopus::initBno055() {
   Printer::printMsg("Octopus", "Initializing BNO055: ");
   if (this->bno055.begin()) {
@@ -178,17 +197,6 @@ void Octopus::initBno055() {
     Serial.println("OK");
   } else {
     bno055Ready = false;
-    Serial.println("Not found");
-  }
-}
-
-void Octopus::initBme280() {
-  Printer::printMsg("Octopus", "Initializing BME280: ");
-  if (this->bme280.begin()) {
-    bme280Ready = true;
-    Serial.println("OK");
-  } else {
-    bme280Ready = false;
     Serial.println("Not found");
   }
 }

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.cpp
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.cpp
@@ -126,7 +126,7 @@ bool Octopus::readBno055(Bno055Values &values) {
   return true;
 }
 
-#if BME280
+#ifdef BME280
 void Octopus::initBme280() {
   Printer::printMsg("Octopus", "Initializing BME280: ");
   if (this->bme280.begin()) {

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.h
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.h
@@ -26,10 +26,14 @@
 #ifndef OCTOPUS_H
 #define OCTOPUS_H
 
-#include <Adafruit_Sensor.h>  // Make sure you have the Adafruit Sensor library installed
-#include <Adafruit_BME680.h>  // Make sure you have the Adafruit BME680 library installed
-#include <Adafruit_BNO055.h>  // Make sure you have the Adafruit BNO055 library installed
+#ifdef BME280
 #include <Adafruit_BME280.h>  // Make sure you have the Adafruit BME280 library installed
+#else
+#include <Adafruit_BME680.h>  // Make sure you have the Adafruit BME680 library installed
+#endif
+
+#include <Adafruit_Sensor.h>  // Make sure you have the Adafruit Sensor library installed
+#include <Adafruit_BNO055.h>  // Make sure you have the Adafruit BNO055 library installed
 #include <utility/imumaths.h>
 #include <Adafruit_NeoPixel.h> // Make sure you have the Adafruit NeoPixel library installed
 
@@ -71,21 +75,25 @@ struct Bme680Values {
 };
 
 class Octopus {
- 
-  Adafruit_BME680 bme680; // I2C
-  Adafruit_BNO055 bno055 = Adafruit_BNO055(55);
-  Adafruit_BME280 bme280; // I2C
-  Adafruit_NeoPixel strip = Adafruit_NeoPixel(2, PIN_NEOPIXEL, NEO_GRBW + NEO_KHZ800);
   
-  void initLights();
-  void initBme680();
-  void initBno055();
+  #ifdef BME280
+  Adafruit_BME280 bme280; // I2C
   void initBme280();
-  void setupNTP();
-
-  bool bme680Ready;
-  bool bno055Ready;
   bool bme280Ready;
+  #else
+  
+  Adafruit_BME680 bme680; // I2C
+  void initBme680();
+  bool bme680Ready;
+  #endif
+
+  Adafruit_BNO055 bno055 = Adafruit_BNO055(55);
+  void initBno055();
+  bool bno055Ready;
+
+  Adafruit_NeoPixel strip = Adafruit_NeoPixel(2, PIN_NEOPIXEL, NEO_GRBW + NEO_KHZ800);
+  void initLights();
+  void setupNTP();
   
   public:
     void begin();
@@ -93,8 +101,12 @@ class Octopus {
     void showColor(char led, char red, char green, char blue, char white);
     float getVcc ();
     bool readBno055(Bno055Values &values);
-    bool readBme680(Bme680Values &values);
+
+    #ifdef BME280
     bool readBme280(Bme680Values &values);
+    #else
+    bool readBme680(Bme680Values &values);
+    #endif
 };
 
 #endif

--- a/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.h
+++ b/octopus-hub-things-example/src/main/octopus/octopus-mqtt/octopus.h
@@ -26,6 +26,7 @@
 #ifndef OCTOPUS_H
 #define OCTOPUS_H
 
+#include "settings.h"
 #ifdef BME280
 #include <Adafruit_BME280.h>  // Make sure you have the Adafruit BME280 library installed
 #else


### PR DESCRIPTION
Instead of dropping support of BME280 because of conflicting libraries like suggested in #15 , we could enable either BME680 or BME280 by a compiler flag