### PR TITLE
firmware update for vorto model 1.1.0

### DIFF
--- a/octopus-bidirectional/iot-device/octopus-hub/octopus-hub.ino
+++ b/octopus-bidirectional/iot-device/octopus-hub/octopus-hub.ino
@@ -73,7 +73,7 @@ void customMessageHandler(JsonObject &root, String command, String replyTopic)
 
   Serial.println(command);
 
-  if (command.equals("setColor") && switchLedPath.equals(path))
+  if (command.equals("switch_led") || (command.equals("setColor") && switchLedPath.equals(path)))
   {
     JsonObject &value = root["value"];
     const char red = value["r"];
@@ -86,10 +86,13 @@ void customMessageHandler(JsonObject &root, String command, String replyTopic)
     root["value"] = "\"Command '" + command + "' executed\"";
     root["status"] = 200;
 
-    String output;
-    value.printTo(output);
+    if(command.equals("setColor") && switchLedPath.equals(path))
+    {
+      String output;
+      value.printTo(output);
 
-    sendLedUpdate(output);
+      sendLedUpdate(output);
+    }
   }
   else if (command.equals("change_update_rate"))
   {

--- a/octopus-bidirectional/iot-device/octopus-hub/octopus-hub.ino
+++ b/octopus-bidirectional/iot-device/octopus-hub/octopus-hub.ino
@@ -59,14 +59,21 @@ void setup()
   Serial.println();
 }
 
+void sendLedUpdate(const String value) {
+  hub.publish(modifyFeaturePropertiesMsg("led", value));
+}
+
 void customMessageHandler(JsonObject &root, String command, String replyTopic)
 {
   const char *dittoTopic = root["topic"];
   JsonObject &headers = root["headers"];
+  const char* path = root["path"];
+
+  String switchLedPath = "/features/led/inbox/messages/setColor";
 
   Serial.println(command);
 
-  if (command.equals("switch_led"))
+  if (command.equals("setColor") && switchLedPath.equals(path))
   {
     JsonObject &value = root["value"];
     const char red = value["r"];
@@ -78,6 +85,11 @@ void customMessageHandler(JsonObject &root, String command, String replyTopic)
 
     root["value"] = "\"Command '" + command + "' executed\"";
     root["status"] = 200;
+
+    String output;
+    value.printTo(output);
+
+    sendLedUpdate(output);
   }
   else if (command.equals("change_update_rate"))
   {

--- a/octopus-bidirectional/iot-device/octopus-hub/octopus.cpp
+++ b/octopus-bidirectional/iot-device/octopus-hub/octopus.cpp
@@ -88,6 +88,17 @@ void Octopus::showColor(char led, char red, char green, char blue, char white) {
   this->strip.show();
 }
 
+bool Octopus::readLed(LedValues &values){
+  uint32_t color = this->strip.getPixelColor(0);
+
+  values.w = (uint8_t)(color >> 24),
+  values.r = (uint8_t)(color >> 16),
+  values.g = (uint8_t)(color >>  8),
+  values.b = (uint8_t)color;
+
+  return true;
+}
+
 float Octopus::getVcc () {
   return ESP.getVcc() / 1000.0;
 }

--- a/octopus-bidirectional/iot-device/octopus-hub/octopus.h
+++ b/octopus-bidirectional/iot-device/octopus-hub/octopus.h
@@ -75,6 +75,13 @@ struct Bme680Values {
   float altitude;
 };
 
+struct LedValues {
+  short r;
+  short g;
+  short b;
+  short w;
+};
+
 class Octopus {
   
   #ifdef BME280
@@ -100,6 +107,7 @@ class Octopus {
     void begin();
     void connectToWifi(char* ssid, const char* password);
     void showColor(char led, char red, char green, char blue, char white);
+    bool readLed(LedValues &values);
     float getVcc ();
     bool readBno055(Bno055Values &values);
 

--- a/octopus-bidirectional/iot-device/octopus-hub/sensorPublish.ino
+++ b/octopus-bidirectional/iot-device/octopus-hub/sensorPublish.ino
@@ -85,7 +85,22 @@ String sensor3dValue(float xValue, float yValue, float zValue, const String& uni
   return output;
 }
 
-void publishSensorData(float power, const Bme680Values& bme680Values, const Bno055Values& bno055Values) {
+String ledValue(short r, short g, short b, short w) {
+  StaticJsonBuffer<200> jsonBuffer;
+  JsonObject& properties = jsonBuffer.createObject();
+  JsonObject& statusProps = properties.createNestedObject("status");
+  statusProps["r"] = r;
+  statusProps["g"] = g;
+  statusProps["b"] = b;
+  statusProps["w"] = w;
+  
+  String output;
+  properties.printTo(output);
+  jsonBuffer.clear();
+  return output;
+}
+
+void publishSensorData(float power, const Bme680Values& bme680Values, const Bno055Values& bno055Values, const LedValues& ledValues) {
 
   updateMinMax(power, bme680Values, bno055Values);
 
@@ -116,6 +131,18 @@ void publishSensorData(float power, const Bme680Values& bme680Values, const Bno0
     modifyFeaturePropertiesMsg("linear_acceleration", sensor3dValue(bno055Values.LinearAccelerationX, bno055Values.LinearAccelerationY, bno055Values.LinearAccelerationZ, "m/s^2")));
   hub.publish(
     modifyFeaturePropertiesMsg("magnetometer", sensor3dValue(bno055Values.magneticFieldStrengthX, bno055Values.magneticFieldStrengthY, bno055Values.magneticFieldStrengthZ, "uT")));
+
+  hub.publish(
+    modifyFeaturePropertiesMsg(
+      "led", 
+      ledValue(
+        ledValues.r, 
+        ledValues.g, 
+        ledValues.b, 
+        ledValues.w
+      )
+    )
+  );
 }
 
 void updateMinMax(float power, const Bme680Values& bme680Values, const Bno055Values& bno055Values) {


### PR DESCRIPTION
To properly support https://vorto.eclipse.org/#/details/com.bosch.iot.suite.example.octopussuiteedition:OctopusSuiteEdition:1.1.0

features:
- supports 'setColor' subject for feature 'led'
- provides latest led color value in 'led' feature like other sensor values
